### PR TITLE
Update references to production publish application

### DIFF
--- a/backup-credentials
+++ b/backup-credentials
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-list-credentials publish-data-beta > publish-production-secrets.json
+list-credentials publish-data-beta-production > publish-production-secrets.json
 list-credentials find-data-beta > find-production-secrets.json
 
 list-credentials publish-data-beta-staging > publish-staging-secrets.json

--- a/terraform-backup
+++ b/terraform-backup
@@ -1,11 +1,11 @@
 #!/usr/local/bin/ruby -w
 require 'json'
 
-publish_prod_secrets = JSON.parse(`./terraform-list-credentials publish-data-beta`)
+publish_prod_secrets = JSON.parse(`./terraform-list-credentials publish-data-beta-production`)
 publish_stag_secrets = JSON.parse(`./terraform-list-credentials publish-data-beta-staging`)
 find_prod_secrets = JSON.parse(`./terraform-list-credentials find-data-beta`)
 find_stag_secrets = JSON.parse(`./terraform-list-credentials find-data-beta-staging`)
-syslog_drain = JSON.parse(`./terraform-syslog-drain publish-data-beta`)
+syslog_drain = JSON.parse(`./terraform-syslog-drain publish-data-beta-production`)
 
 secrets = [publish_prod_secrets, publish_stag_secrets, find_prod_secrets, find_stag_secrets].reduce(&:merge)
 secrets = secrets.map { |k, v| [k, JSON.dump(v)] }.to_h


### PR DESCRIPTION
The application name has changed so that it conforms to conventions needed for production to staging sign-on sync.

See https://trello.com/c/mBViuo1y